### PR TITLE
docs: fix ModelScope badge labelColor encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <a href="https://huggingface.co/moonshotai" target="_blank"><img alt="Hugging Face" src="https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Moonshot%20AI-ffc107?color=ffc107&logoColor=white"/></a>
   <a href="https://twitter.com/kimi_moonshot" target="_blank"><img alt="Twitter Follow" src="https://img.shields.io/badge/Twitter-Kimi.ai-white?logo=x&logoColor=white"/></a>
   <a href="https://discord.gg/TYU2fdJykW" target="_blank"><img alt="Discord" src="https://img.shields.io/badge/Discord-Kimi.ai-white?logo=discord&logoColor=white"/></a>
-  <a href="https://modelscope.cn/organization/moonshotai" target="_blank"><img alt="ModelScope" src="https://img.shields.io/badge/ModelScope-Moonshot%20AI-white?labelColor=rgb(99%2C%2074%2C%255)"/></a>
+  <a href="https://modelscope.cn/organization/moonshotai" target="_blank"><img alt="ModelScope" src="https://img.shields.io/badge/ModelScope-Moonshot%20AI-white?labelColor=rgb(99%2C%2074%2C%20255)"/></a>
 </div>
 <div align="center" style="line-height: 1;">
   <a href="https://huggingface.co/moonshotai/Kimi-K3/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/badge/License-Kimi_K3-f5de53?&color=f5de53"/></a>


### PR DESCRIPTION
Correct the URL-encoded RGB value so the badge uses rgb(99, 74, 255) instead of a malformed %255 suffix.


## Before
<img width="1220" height="562" alt="CleanShot 2026-07-28 at 00 40 41@2x" src="https://github.com/user-attachments/assets/b7d7214d-b269-40c9-b2e2-7e9dfd715fe4" />


## After
<img width="1326" height="540" alt="CleanShot 2026-07-28 at 00 41 07@2x" src="https://github.com/user-attachments/assets/561bc695-576d-4892-b04f-a2e559a3d1d0" />
