### PR TITLE
docs: fix reasoning_content field name and add Video to the modality row

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Kimi K3 is an open-weight, native multimodal agentic model and our most capable 
 </tr>
 <tr>
 <td align="center" style="vertical-align: middle; text-align: center"><strong>Modality</strong></td>
-<td align="center" style="vertical-align: middle; text-align: center">Text, Image</td>
+<td align="center" style="vertical-align: middle; text-align: center">Text, Image, Video</td>
 </tr>
 </tbody>
 </table>
@@ -646,7 +646,7 @@ def chat_with_preserved_thinking(client: openai.OpenAI, model_name: str):
         reasoning_effort="max",
     )
     # the assistant should mention 215 and 222 that appear in the prior reasoning content
-    print(f"response: {response.choices[0].message.reasoning}")
+    print(f"response: {response.choices[0].message.reasoning_content}")
     return response.choices[0].message.content
 ```
 


### PR DESCRIPTION
Two inconsistencies inside the README. Both are checkable against the document itself — no external knowledge needed.

## 1. The usage example reads the wrong field

Section 6 states the model *"will return `reasoning_content`"*, and the example message uses `reasoning_content` as its key. The print statement then reads `.reasoning`:

```python
print(f"response: {response.choices[0].message.reasoning}")
```

Counting occurrences in that section: `reasoning_content` appears at lines 617, 619 and 632; `.reasoning` appears once, at line 649. Copy-pasting the snippet prints `None` instead of the preserved thinking it exists to demonstrate — which is the entire point of the example.

## 2. The Model Summary table omits video

The table lists:

| Modality | Text, Image |
|---|---|

But the Key Features immediately above say Kimi K3 *"understands text, images, and video within the same model"*, and the evaluation table reports:

| Video-MME (w. sub) | **90.0** |
|---|---|

So the spec table and the benchmark table give a reader contradictory answers about whether video is supported. Given the model is benchmarked on video and the feature list claims it, the table row looks like the thing that's out of date.

---

Diff is 2 lines. Happy to split into two PRs if you'd prefer them reviewed separately, and equally happy to close this if the modality row is deliberate and video is served by something other than the base weights.

Thanks for shipping the weights openly.