### PR TITLE
docs: fix missing article 'an' before 'API' in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ Kimi K3 applies quantization-aware training from the SFT stage onward, using MXF
 ## 5. Deployment
 
 > [!Note]
-> You can access Kimi K3's API on https://platform.kimi.ai by selecting `kimi-k3`, and we provide OpenAI/Anthropic-compatible API for you. Currently, Kimi K3 is recommended to run on the following inference engines:
+> You can access Kimi K3's API on https://platform.kimi.ai by selecting `kimi-k3`, and we provide an OpenAI/Anthropic-compatible API for you. Currently, Kimi K3 is recommended to run on the following inference engines:
 
 - [vLLM](https://github.com/vllm-project/vllm) — see [recipes](https://recipes.vllm.ai/moonshotai/Kimi-K3)
 - [SGLang](https://github.com/sgl-project/sglang) — see [cookbook](https://docs.sglang.io/cookbook/autoregressive/Moonshotai/Kimi-K3)


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `README.md` (line 608).

## Problem

Missing article "an" before "OpenAI/Anthropic-compatible API". The singular countable noun phrase "API" requires an article.

The problematic text:

```markdown
we provide OpenAI/Anthropic-compatible API for you
```

## Fix

Replaced with:

```markdown
we provide an OpenAI/Anthropic-compatible API for you
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text