### PR TITLE
docs: clarify routed expert counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,11 @@ Kimi K3 is an open-weight, native multimodal agentic model and our most capable 
 <td align="center" style="vertical-align: middle; text-align: center">3072</td>
 </tr>
 <tr>
-<td align="center" style="vertical-align: middle; text-align: center"><strong>Number of Experts</strong></td>
+<td align="center" style="vertical-align: middle; text-align: center"><strong>Number of Routed Experts</strong></td>
 <td align="center" style="vertical-align: middle; text-align: center">896</td>
 </tr>
 <tr>
-<td align="center" style="vertical-align: middle; text-align: center"><strong>Selected Experts per Token</strong></td>
+<td align="center" style="vertical-align: middle; text-align: center"><strong>Routed Experts Selected per Token</strong></td>
 <td align="center" style="vertical-align: middle; text-align: center">16</td>
 </tr>
 <tr>


### PR DESCRIPTION
## Summary

Clarify the expert-count terminology in the model summary table.

## Rationale

The Kimi K3 technical report distinguishes between 896 routed experts and 2 shared experts. The existing label, `Number of Experts`, can be read as the total number of all expert modules, while the value specifically refers to routed experts.

The selected-expert field is also clarified to indicate that the value 16 refers to routed experts selected per token.

## Changes

- Rename `Number of Experts` to `Number of Routed Experts`
- Rename `Selected Experts per Token` to `Routed Experts Selected per Token`
- Keep all numerical values unchanged

## Validation

- Cross-checked the terminology against the Kimi K3 technical report
- Confirmed that the change is documentation-only
- Ran `git diff --check`